### PR TITLE
update package index files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM phusion/baseimage:0.9.16
 
+# Update package index files
+RUN apt-get update
+
 # Install Node.js and Grunt
 RUN curl -sL https://deb.nodesource.com/setup | sudo bash -
 RUN apt-get install -y build-essential nodejs


### PR DESCRIPTION
package index files need to be updated otherwise the docker build process exits with an error when trying to download outdated packages.
