### PR TITLE
smaller image size, seperate install script, corrected directory privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,11 +69,14 @@ RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; \
 	echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile; \
 	/install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile; \
 	rm -r /install-tl-unx; \
-	rm install-tl-unx.tar.gz; \
-	tlmgr install latexmk
+	rm install-tl-unx.tar.gz
 
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2015/bin/x86_64-linux/
 
+# update tlmgr and install latexmk
+RUN tlmgr update --self; \
+	tlmgr install latexmk
+	
 # Install Aspell
 RUN apt-get install -y aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns aspell-or aspell-pa aspell-pl aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-ta aspell-te aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM phusion/baseimage:0.9.16
 
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2015/bin/x86_64-linux/
+
 # Install Sharelatex
 COPY install.sh /install.sh
 RUN /install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,104 +1,38 @@
 FROM phusion/baseimage:0.9.16
 
-# Install Node.js and Grunt
-# update package chache
-RUN curl -sL https://deb.nodesource.com/setup | sudo bash -
-RUN apt-get update && apt-get install -y build-essential nodejs
-RUN npm install -g grunt-cli
+# Install Sharelatex
+COPY install.sh /install.sh
+RUN /install.sh
 
-# Set up sharelatex user and home directory
-RUN adduser --system --group --home /var/www/sharelatex --no-create-home sharelatex; \
-	mkdir -p /var/lib/sharelatex; \
-	chown sharelatex:sharelatex /var/lib/sharelatex; \
-	mkdir -p /var/log/sharelatex; \
-	chown sharelatex:sharelatex /var/log/sharelatex;
+########################
+# COPY config files and scripts to the image
+########################
+# nginx
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/sharelatex.conf /etc/nginx/sites-enabled/sharelatex.conf
+COPY runit/nginx.sh /etc/service/nginx/run
 
-# Install ShareLaTeX
-RUN apt-get install -y git python
-RUN git clone -b release https://github.com/sharelatex/sharelatex.git /var/www/sharelatex
-RUN cd /var/www/sharelatex && git pull origin release
-
-# zlib1g-dev is needed to compile the synctex binaries in the CLSI during `grunt install`.
-RUN apt-get install -y zlib1g-dev
-
-RUN cd /var/www/sharelatex; \
-	npm install; \
-	grunt install;
-
-# Minify js assets
-RUN cd /var/www/sharelatex/web; \
-	grunt compile:minify;
-
-# Install Nginx as a reverse proxy
-RUN apt-get install -y nginx;
-RUN rm /etc/nginx/sites-enabled/default
-ADD nginx/nginx.conf /etc/nginx/nginx.conf
-ADD nginx/sharelatex.conf /etc/nginx/sites-enabled/sharelatex.conf
-
-RUN mkdir /etc/service/nginx
-ADD runit/nginx.sh /etc/service/nginx/run
-
-# Set up ShareLaTeX services to run automatically on boot
-RUN mkdir /etc/service/chat-sharelatex; \
-	mkdir /etc/service/clsi-sharelatex; \
-	mkdir /etc/service/docstore-sharelatex; \
-	mkdir /etc/service/document-updater-sharelatex; \
-	mkdir /etc/service/filestore-sharelatex; \
-	mkdir /etc/service/real-time-sharelatex; \
-	mkdir /etc/service/spelling-sharelatex; \
-	mkdir /etc/service/tags-sharelatex; \
-	mkdir /etc/service/track-changes-sharelatex; \
-	mkdir /etc/service/web-sharelatex;
-
-ADD runit/chat-sharelatex.sh             /etc/service/chat-sharelatex/run
-ADD runit/clsi-sharelatex.sh             /etc/service/clsi-sharelatex/run
-ADD runit/docstore-sharelatex.sh         /etc/service/docstore-sharelatex/run
-ADD runit/document-updater-sharelatex.sh /etc/service/document-updater-sharelatex/run
-ADD runit/filestore-sharelatex.sh        /etc/service/filestore-sharelatex/run
-ADD runit/real-time-sharelatex.sh        /etc/service/real-time-sharelatex/run
-ADD runit/spelling-sharelatex.sh         /etc/service/spelling-sharelatex/run
-ADD runit/tags-sharelatex.sh             /etc/service/tags-sharelatex/run
-ADD runit/track-changes-sharelatex.sh    /etc/service/track-changes-sharelatex/run
-ADD runit/web-sharelatex.sh              /etc/service/web-sharelatex/run
-
-# Install TexLive basic scheme
-RUN apt-get install -y wget
-RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; \
-	mkdir /install-tl-unx; \
-	tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1; \
-	echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile; \
-	/install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile; \
-	rm -r /install-tl-unx; \
-	rm install-tl-unx.tar.gz
-
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2015/bin/x86_64-linux/
-
-# update tlmgr and install latexmk
-RUN tlmgr update --self; \
-	tlmgr install latexmk
-	
-# Install Aspell
-RUN apt-get install -y aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns aspell-or aspell-pa aspell-pl aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-ta aspell-te aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
-
-# Install unzip for file uploads
-RUN apt-get install -y unzip
-
-# Install imagemagick for image conversions
-RUN apt-get install -y imagemagick optipng
+# services
+COPY runit/chat-sharelatex.sh /etc/service/chat-sharelatex/run
+COPY runit/clsi-sharelatex.sh /etc/service/clsi-sharelatex/run
+COPY runit/docstore-sharelatex.sh /etc/service/docstore-sharelatex/run
+COPY runit/document-updater-sharelatex.sh /etc/service/document-updater-sharelatex/run
+COPY runit/filestore-sharelatex.sh /etc/service/filestore-sharelatex/run
+COPY runit/real-time-sharelatex.sh /etc/service/real-time-sharelatex/run
+COPY runit/spelling-sharelatex.sh /etc/service/spelling-sharelatex/run
+COPY runit/tags-sharelatex.sh /etc/service/tags-sharelatex/run
+COPY runit/track-changes-sharelatex.sh /etc/service/track-changes-sharelatex/run
+COPY runit/web-sharelatex.sh /etc/service/web-sharelatex/run
 
 # phusion/baseimage init script
-ADD 00_regen_sharelatex_secrets.sh  /etc/my_init.d/00_regen_sharelatex_secrets.sh
-ADD 00_make_sharelatex_data_dirs.sh /etc/my_init.d/00_make_sharelatex_data_dirs.sh
-ADD 00_set_docker_host_ipaddress.sh /etc/my_init.d/00_set_docker_host_ipaddress.sh
-ADD 99_migrate.sh /etc/my_init.d/99_migrate.sh
+COPY 00_regen_sharelatex_secrets.sh  /etc/my_init.d/00_regen_sharelatex_secrets.sh
+COPY 00_make_sharelatex_data_dirs.sh /etc/my_init.d/00_make_sharelatex_data_dirs.sh
+COPY 00_set_docker_host_ipaddress.sh /etc/my_init.d/00_set_docker_host_ipaddress.sh
+COPY 99_migrate.sh /etc/my_init.d/99_migrate.sh
 
 # Install ShareLaTeX settings file
-RUN mkdir /etc/sharelatex
 ADD settings.coffee /etc/sharelatex/settings.coffee
 ENV SHARELATEX_CONFIG /etc/sharelatex/settings.coffee
-
-# sharelatex user should be owner for its home directory
-RUN chown -R sharelatex:sharelatex /var/www/sharelatex
 
 EXPOSE 80
 

--- a/install.sh
+++ b/install.sh
@@ -53,8 +53,6 @@ echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
 /install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile
 rm install-tl-unx.tar.gz
 
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2015/bin/x86_64-linux/
-
 # update tlmgr and install latexmk
 tlmgr update --self
 tlmgr install latexmk

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Install Node.js and Grunt
+# update package chache
+# zlib1g-dev is needed to compile the synctex binaries in the CLSI during `grunt install`.
+# Install unzip for file uploads
+# Install imagemagick for image conversions
+curl -sL https://deb.nodesource.com/setup | sudo bash -
+apt-get update && apt-get install -y build-essential nodejs git python zlib1g-dev nginx wget unzip imagemagick optipng
+npm install -g grunt-cli
+
+# Set up sharelatex user and home directory
+adduser --system --group --home /var/www/sharelatex --no-create-home sharelatex
+mkdir -p /var/lib/sharelatex
+chown sharelatex:sharelatex /var/lib/sharelatex
+mkdir -p /var/log/sharelatex
+chown sharelatex:sharelatex /var/log/sharelatex
+
+# Install ShareLaTeX
+git clone -b release https://github.com/sharelatex/sharelatex.git /var/www/sharelatex
+cd /var/www/sharelatex
+git pull origin release
+npm install
+grunt install
+
+# Minify js assets
+cd /var/www/sharelatex/web
+grunt compile:minify
+
+# Install Nginx as a reverse proxy
+rm /etc/nginx/sites-enabled/default
+mkdir /etc/service/nginx
+
+# Set up ShareLaTeX services to run automatically on boot
+mkdir /etc/service/chat-sharelatex
+mkdir /etc/service/clsi-sharelatex
+mkdir /etc/service/docstore-sharelatex
+mkdir /etc/service/document-updater-sharelatex
+mkdir /etc/service/filestore-sharelatex
+mkdir /etc/service/real-time-sharelatex
+mkdir /etc/service/spelling-sharelatex
+mkdir /etc/service/tags-sharelatex
+mkdir /etc/service/track-changes-sharelatex
+mkdir /etc/service/web-sharelatex
+
+mkdir /etc/sharelatex
+
+# Install TexLive basic scheme
+wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+mkdir /install-tl-unx
+tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1
+echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
+/install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile
+rm install-tl-unx.tar.gz
+
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2015/bin/x86_64-linux/
+
+# update tlmgr and install latexmk
+tlmgr update --self
+tlmgr install latexmk
+
+# Install Aspell
+apt-get install -y aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns aspell-or aspell-pa aspell-pl aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-ta aspell-te aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
+
+# sharelatex user should be owner for its home directory
+chown -R sharelatex:sharelatex /var/www/sharelatex


### PR DESCRIPTION
**seperate install script**
now builds much faster and creates a smaller image, can now be automatically build on docker hub

**added chown for /var/www/sharelatex**
sharelatex user should be owner of its home directory, otherwise no extra fonts could be used

**apt-get update**
changed apt-get update command to occur only once at the beginning, not needed more then once

**texlive**
changed texlive install command to update tlmgr to its latest version, combined several RUN commands to one
