### PR TITLE
Fix db.sqlite file missing issue

### DIFF
--- a/init_scripts/00_make_sharelatex_data_dirs.sh
+++ b/init_scripts/00_make_sharelatex_data_dirs.sh
@@ -20,5 +20,8 @@ chown www-data:www-data /var/lib/sharelatex/tmp/uploads
 mkdir -p /var/lib/sharelatex/tmp/dumpFolder
 chown www-data:www-data /var/lib/sharelatex/tmp/dumpFolder
 
+if [ ! -f /var/lib/sharelatex/data/db.sqlite ]; then
+	touch /var/lib/sharelatex/data/db.sqlite
+fi
 
 chown www-data:www-data /var/lib/sharelatex/data/db.sqlite


### PR DESCRIPTION
Hi,

From scratch (no data), Sharelatex container is failed when i want to start it. The problem is due to a missing file (_db.sqlite_) during the execution of the _00_make_sharelatex_data_dirs.sh_ script. 

From this pull request, i propose to check if the file is existing, if not i create an empty file.

Mickael
