### PR TITLE
Create Dockerfile-base

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -24,7 +24,7 @@ RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile; \
 RUN rm -r /install-tl-unx; \
 	rm install-tl-unx.tar.gz
 
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2016/bin/x86_64-linux/
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2017/bin/x86_64-linux/
 RUN tlmgr install latexmk
 RUN tlmgr install texcount
 


### PR DESCRIPTION
Update to 2017 texlive on the path since that's where the default install now lives.

For issue #77