### PR TITLE
Run filestore with node6

### DIFF
--- a/runit/filestore-sharelatex/run
+++ b/runit/filestore-sharelatex/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 export SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee
-exec /sbin/setuser www-data /usr/bin/node /var/www/sharelatex/filestore/app.js >> /var/log/sharelatex/filestore.log 2>&1
+exec /sbin/setuser www-data /usr/bin/node6 /var/www/sharelatex/filestore/app.js >> /var/log/sharelatex/filestore.log 2>&1


### PR DESCRIPTION
Fixes https://github.com/overleaf/issues/issues/2181.

Debugging showed the problem was caused by piping file stream readers to the request response. Running the service in node v6 instead of node v10 fixes the problem.