### PR TITLE
Override v1.url setting with "" instead of null

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -199,7 +199,7 @@ settings =
 		# overrides v1.url to indicate via Feature Flags that Overleaf V1
 		# is not available	
 		v1:
-			url: null    
+			url: ""    
 	references:{}
 	notifications:undefined
 


### PR DESCRIPTION
It turns that `settings-module` doesn't override as expected when property value is `null`. This fixes the check (related to https://github.com/overleaf/web-internal/pull/2127)