### PR TITLE
[misc] narrow down the rw accessible directories for the run user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ADD ${baseDir}/git-revision.js /var/www/git-revision.js
 RUN cd /var/www && npm install
 
 
-# Replace overleaf/config/services.js with the list of available 
+# Replace overleaf/config/services.js with the list of available
 # services in Overleaf Community Edition
 # --------------------------------------------------------------
 ADD ${baseDir}/services.js /var/www/sharelatex/config/services.js
@@ -47,11 +47,6 @@ RUN bash -c 'cd /var/www/sharelatex && source ./bin/compile-services'
 # Links CLSI sycntex to its default location
 # ------------------------------------------
 RUN ln -s /var/www/sharelatex/clsi/bin/synctex /opt/synctex
-
-
-# Change application ownership to www-data
-# ----------------------------------------
-RUN	chown -R www-data:www-data /var/www/sharelatex;
 
 
 # Copy runit service startup scripts to its location

--- a/init_scripts/00_make_sharelatex_data_dirs.sh
+++ b/init_scripts/00_make_sharelatex_data_dirs.sh
@@ -31,9 +31,3 @@ if [ ! -e "/var/lib/sharelatex/data/db.sqlite" ]; then
 fi
 
 chown www-data:www-data /var/lib/sharelatex/data/db.sqlite
-
-# TODO(das7pad): remove once the files are hashed in the build stage
-chown www-data:www-data \
-  /var/www/sharelatex/web/public/minjs/ \
-  /var/www/sharelatex/web/public/minjs/libs/ \
-  /var/www/sharelatex/web/public/stylesheets/ \

--- a/init_scripts/00_make_sharelatex_data_dirs.sh
+++ b/init_scripts/00_make_sharelatex_data_dirs.sh
@@ -26,10 +26,14 @@ chown www-data:www-data /var/lib/sharelatex/tmp/uploads
 mkdir -p /var/lib/sharelatex/tmp/dumpFolder
 chown www-data:www-data /var/lib/sharelatex/tmp/dumpFolder
 
-chown www-data:www-data /var/www/
-
 if [ ! -e "/var/lib/sharelatex/data/db.sqlite" ]; then
        touch /var/lib/sharelatex/data/db.sqlite
 fi
 
 chown www-data:www-data /var/lib/sharelatex/data/db.sqlite
+
+# TODO(das7pad): remove once the files are hashed in the build stage
+chown www-data:www-data \
+  /var/www/sharelatex/web/public/minjs/ \
+  /var/www/sharelatex/web/public/minjs/libs/ \
+  /var/www/sharelatex/web/public/stylesheets/ \


### PR DESCRIPTION
The proposed patch reduces the size of the main stage by about 1.5GB [1].

This large saving is possible by eliminating a recursive ownership change of the directory `/var/www/sharelatex`.

Changing the ownership of an arbitrary file results in two copies of said file in the final docker image.
The overlay file system stores the content and meta data (including the owner) of a file tied together. This results in a new pair upon changing the content and/or the meta data of a file.

~The web service creates copies of some files at run time to help with browser cache invalidating [2].
This requires write access on some directories in the `public/` directory of the web-service.
We can remove the added lines in `init_scripts/00_make_sharelatex_data_dirs.sh` once the files are created at build time.~ Done in https://github.com/overleaf/docker-image/pull/119/commits/3c7ee557dc1f8ff67b5e19c72ddd3471004ba9d7

Basic editor functionality has been tested. 

---
[1] The image size is measured with `docker save IMAGE_ID | wc --bytes`. I am using the base image and final image with tag `2.0-beta2`. The image `sharelatex/sharelatex:2.0-beta-2` (`sha256:11ac166efa7067e8853fe6b6caa88637035a58a72d1e34c2130f178d85856cf4`) totals `4965017088` Bytes and an image build today using the proposed branch totals `3381254144` Bytes. That's a difference of 1510MB.

[2] https://github.com/overleaf/web/blob/7b2e648b96af3bf87780f7ef6e7a737d0be1a600/app/src/infrastructure/ExpressLocals.js#L61