### PR TITLE
[misc] minimize base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ ADD ${baseDir}/runit /etc/service
 
 # Configure nginx
 # ---------------
-RUN rm /etc/nginx/sites-enabled/default
 ADD ${baseDir}/nginx/nginx.conf /etc/nginx/nginx.conf
 ADD ${baseDir}/nginx/sharelatex.conf /etc/nginx/sites-enabled/sharelatex.conf
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -19,6 +19,8 @@ RUN apt-get update \
 &&  apt-get install -y nodejs \
     \
 &&  rm -rf \
+      /etc/nginx/nginx.conf \
+      /etc/nginx/sites-enabled/default \
       /var/lib/apt/lists/*
 
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -9,8 +9,13 @@ ENV baseDir .
 
 # Install dependencies
 # --------------------
-RUN apt-get update
-RUN apt-get install -y build-essential wget net-tools unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
+RUN apt-get update \
+&&  apt-get install -y \
+      build-essential wget net-tools unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev \
+      aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu \
+    \
+&&  rm -rf \
+      /var/lib/apt/lists/*
 
 
 # Install qpdf

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -10,7 +10,6 @@ ENV baseDir .
 # Install dependencies
 # --------------------
 RUN apt-get update
-RUN apt-get install -y sudo
 RUN apt-get install -y build-essential wget net-tools unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
 
 
@@ -24,7 +23,7 @@ RUN ./configure && make && make install && ldconfig
 
 # Install Node
 # ------------
-RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g grunt-cli
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -15,10 +15,19 @@ RUN apt-get install -y build-essential wget net-tools unzip time imagemagick opt
 
 # Install qpdf
 # ------------
-WORKDIR /opt
-RUN wget https://s3.amazonaws.com/sharelatex-random-files/qpdf-6.0.0.tar.gz && tar xzf qpdf-6.0.0.tar.gz
-WORKDIR /opt/qpdf-6.0.0
-RUN ./configure && make && make install && ldconfig
+RUN mkdir /opt/qpdf \
+    \
+&&  curl -sSL \
+      https://s3.amazonaws.com/sharelatex-random-files/qpdf-6.0.0.tar.gz \
+    | tar -xzC /opt/qpdf --strip-components=1 \
+    \
+&&  cd /opt/qpdf/ \
+&&    ./configure \
+&&    make \
+&&    make install \
+&&    ldconfig \
+    \
+&&  rm -rf /opt/qpdf
 
 
 # Install Node

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -56,6 +56,9 @@ RUN mkdir /install-tl-unx \
       ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz \
     | tar -xzC /install-tl-unx --strip-components=1 \
     \
+&&  echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile \
+&&  echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile \
+&&  echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile \
 &&  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile \
     \
 &&  /install-tl-unx/install-tl \

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -43,7 +43,9 @@ RUN mkdir /opt/qpdf \
 
 # Install Grunt
 # ------------
-RUN npm install -g grunt-cli
+RUN npm install -g \
+      grunt-cli \
+&&  rm -rf /root/.npm
 
 # Install TexLive
 # ---------------

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -38,26 +38,26 @@ RUN npm install -g grunt-cli
 
 # Install TexLive
 # ---------------
-RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \
-	mkdir /install-tl-unx && \
-	tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1
-RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile && \
-	/install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile
+ARG TEXLIVE_MIRROR=http://mirror.ctan.org/systems/texlive/tlnet
 
-# CTAN mirrors occasionally fail, in that case install TexLive against an
-# specific server, for example http://ctan.crest.fr
-# RUN wget http://ctan.crest.fr/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz && \
-# 	  mkdir /install-tl-unx && \
-# 	  tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1
-# RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile && \
-# 	  /install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile  \
-# 	  -repository  http://ctan.crest.fr/tex-archive/systems/texlive/tlnet/
+ENV PATH "${PATH}:/usr/local/texlive/2019/bin/x86_64-linux"
 
-RUN rm -r /install-tl-unx; \
-	rm install-tl-unx.tar.gz
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2019/bin/x86_64-linux/
-RUN tlmgr install latexmk
-RUN tlmgr install texcount
+RUN mkdir /install-tl-unx \
+&&  curl -sSL \
+      ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz \
+    | tar -xzC /install-tl-unx --strip-components=1 \
+    \
+&&  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile \
+    \
+&&  /install-tl-unx/install-tl \
+      -profile /install-tl-unx/texlive.profile \
+      -repository ${TEXLIVE_MIRROR} \
+    \
+&&  tlmgr install --repository ${TEXLIVE_MIRROR} \
+      latexmk \
+      texcount \
+    \
+&&  rm -rf /install-tl-unx
 
 
 # Set up sharelatex user and home directory

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -14,6 +14,10 @@ RUN apt-get update \
       build-essential wget net-tools unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev \
       aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu \
     \
+# install Node.JS 10
+&&  curl -sSL https://deb.nodesource.com/setup_10.x | bash - \
+&&  apt-get install -y nodejs \
+    \
 &&  rm -rf \
       /var/lib/apt/lists/*
 
@@ -35,10 +39,8 @@ RUN mkdir /opt/qpdf \
 &&  rm -rf /opt/qpdf
 
 
-# Install Node
+# Install Grunt
 # ------------
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install -y nodejs
 RUN npm install -g grunt-cli
 
 # Install TexLive

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -12,6 +12,7 @@ ENV baseDir .
 RUN apt-get update \
 &&  apt-get install -y \
       build-essential wget net-tools unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev \
+      qpdf \
       aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu \
     \
 # install Node.JS 10
@@ -19,27 +20,10 @@ RUN apt-get update \
 &&  apt-get install -y nodejs \
     \
 &&  rm -rf \
+# We are adding a custom nginx config in the main Dockerfile.
       /etc/nginx/nginx.conf \
       /etc/nginx/sites-enabled/default \
       /var/lib/apt/lists/*
-
-
-# Install qpdf
-# ------------
-RUN mkdir /opt/qpdf \
-    \
-&&  curl -sSL \
-      https://s3.amazonaws.com/sharelatex-random-files/qpdf-6.0.0.tar.gz \
-    | tar -xzC /opt/qpdf --strip-components=1 \
-    \
-&&  cd /opt/qpdf/ \
-&&    ./configure \
-&&    make \
-&&    make install \
-&&    ldconfig \
-    \
-&&  rm -rf /opt/qpdf
-
 
 # Install Grunt
 # ------------
@@ -49,6 +33,12 @@ RUN npm install -g \
 
 # Install TexLive
 # ---------------
+# CTAN mirrors occasionally fail, in that case install TexLive against an
+# specific server, for example http://ctan.crest.fr
+#
+# # docker build \
+#     --build-arg TEXLIVE_MIRROR=http://ctan.crest.fr/tex-archive/systems/texlive/tlnet \
+#     -f Dockerfile-base -t sharelatex/sharelatex-base .
 ARG TEXLIVE_MIRROR=http://mirror.ctan.org/systems/texlive/tlnet
 
 ENV PATH "${PATH}:/usr/local/texlive/2019/bin/x86_64-linux"


### PR DESCRIPTION
With careful refactoring of image layers and additional configuration options for texlive, we can reduce the image size of the base image by about 322MB [1].

Once a file is included in an image layer, we can only hide it in the upper layers by deleting it. To not include an arbitrary file we need to delete it in the same layer it was created in - e.g. download the texlive installer, run the installer and delete it in the same RUN layer.

This PR drops these categories of artifacts: 
- `sudo` package - it was used to install node10, but as we run this as root we can omit sudo. 
- qpdf source
- texlive installer files, documentation and source files.
- apt package lists
- default nginx configuration - overwritten in the main stage
- npm download cache

In upgrading qpdf to a more modern version and pulling it as ubuntu package we can save another 38MB. The installation from source creates many artifacts we do not need, resulting in a 40MB layer. The ubuntu qpdf package is version 8.0.2 and has a footprint of 2MB on disk.
Given that we are only using the public api in clsi [2], this should not be an issue? This could be subject to a follow up PR.

---
[1] The image size is measured with `docker save IMAGE_ID | wc --bytes`. I am using the base image with tag `2.0-beta2` as reference. The image `sharelatex/sharelatex-base:2.0-beta-2` (`sha256:11ac166efa7067e8853fe6b6caa88637035a58a72d1e34c2130f178d85856cf4`) totals `1576994816` Bytes and an image build today using the proposed branch totals `1238641152` Bytes. That's a difference of 322MB.
[2] https://github.com/overleaf/clsi/blob/a62ff6e248d624c5ad78dbf08bb4613b043abdc2/app/coffee/OutputFileOptimiser.coffee#L35