### PR TITLE
[nginx] simplify the root specification for sendfile

### DIFF
--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -2,7 +2,7 @@ server {
 	listen         80;
 	server_name    _; # Catch all, see http://nginx.org/en/docs/http/server_names.html
 
-	set $static_path /var/www/sharelatex/web/public;
+	root /var/www/sharelatex/web/public/;
 
 	location / {
 		proxy_pass http://127.0.0.1:3000;
@@ -14,7 +14,7 @@ server {
 		proxy_read_timeout 3m;
 		proxy_send_timeout 3m;
 	}
-	
+
 	location /socket.io {
 		proxy_pass http://127.0.0.1:3026;
 		proxy_http_version 1.1;
@@ -29,16 +29,13 @@ server {
 
 	location /stylesheets {
 		expires 1y;
-		root $static_path/;
 	}
 
 	location /minjs {
 		expires 1y;
-		root $static_path/;
 	}
 
 	location /img {
 		expires 1y;
-		root $static_path/;
 	}
 }


### PR DESCRIPTION
The `$static_path` variable is a constant actually. We can specify the `root` option at the top layer then.

The proxy locations simply ignore the `root` option.