### PR TITLE
[init] bail out in case the db access fails

### DIFF
--- a/init_scripts/00_make_sharelatex_data_dirs.sh
+++ b/init_scripts/00_make_sharelatex_data_dirs.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 mkdir -p /var/lib/sharelatex/data
 chown www-data:www-data /var/lib/sharelatex/data
 

--- a/init_scripts/00_regen_sharelatex_secrets.sh
+++ b/init_scripts/00_regen_sharelatex_secrets.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -e -o pipefail
 
 # generate secrets and defines them as environment variables
 # https://github.com/phusion/baseimage-docker#centrally-defining-your-own-environment-variables

--- a/init_scripts/00_set_docker_host_ipaddress.sh
+++ b/init_scripts/00_set_docker_host_ipaddress.sh
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -e -o pipefail
+
 # See the bottom of http://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach
 echo "`route -n | awk '/UG[ \t]/{print $2}'` dockerhost" >> /etc/hosts

--- a/init_scripts/98_check_db_access.sh
+++ b/init_scripts/98_check_db_access.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 echo "Checking can connect to mongo and redis"
 cd /var/www/sharelatex && grunt check:redis
 cd /var/www/sharelatex && grunt check:mongo

--- a/init_scripts/99_migrate.sh
+++ b/init_scripts/99_migrate.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 which node
 which grunt
 ls -al /var/www/sharelatex/migrations


### PR DESCRIPTION
There is an init script that checks for data base access. Unfortunately it does not stop the startup of the container in case of a failure. Instead it just prints error messages and moves on to start overleaf.

The grunt task signals the error case with a non zero exit code and the init daemon of the phusion base image can handle error codes accordingly.

A patch is trivial: stop the shell script upon a failure via `set -e`. 