### PR TITLE
[settings] produce a consistent redis config for every service

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -81,6 +81,9 @@ settings =
 		lock: redisConfig
 		history: redisConfig
 		websessions: redisConfig
+		api: redisConfig
+		pubsub: redisConfig
+		project_history: redisConfig
 
 	# The compile server (the clsi) uses a SQL database to cache files and
 	# meta-data. sqllite is the default, and the load is low enough that this will


### PR DESCRIPTION
Only some of the redis configs are overwritten with the provided `SHARELATEX_REDIS_HOST` environment variable.

There is a note about this in the docker-compose file of the main overleaf repository [1]. This PR fixes the actual issue.

---
[1] https://github.com/overleaf/overleaf/blob/431aa43b63e3d26dd374ac6209a35d8e7da3421c/docker-compose.yml#L28