### PR TITLE
Disable project-history via settings

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -200,6 +200,8 @@ settings =
 		# is not available
 		v1:
 			url: ""
+		project_history:
+			enabled: false
 	references:{}
 	notifications:undefined
 


### PR DESCRIPTION
Disables `project-history` service call. Flag is used by `document-updater` to flush changes after deletion https://github.com/overleaf/document-updater/blob/master/app/coffee/HistoryManager.coffee#L30

Fixes https://github.com/overleaf/overleaf/issues/644.