### PR TITLE
Overleaf CE Hotfix 2.0.1

### DIFF
--- a/hotfix/2.0.1/Dockerfile
+++ b/hotfix/2.0.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM sharelatex/sharelatex:2.0.0
+
+
+# Patch 1: Fixes project deletion (https://github.com/overleaf/overleaf/issues/644)
+ADD disable_project_history.patch /etc/sharelatex/disable_project_history.patch
+RUN cd /etc/sharelatex && \
+    patch < disable_project_history.patch
+
+
+# Patch 2: Fixes admin creation via CLI (https://github.com/overleaf/overleaf/issues/647)
+ADD create_and_destroy_users.patch /var/www/sharelatex/tasks/create_and_destroy_users.patch
+RUN cd /var/www/sharelatex/tasks/ && \
+    patch < create_and_destroy_users.patch

--- a/hotfix/2.0.1/create_and_destroy_users.patch
+++ b/hotfix/2.0.1/create_and_destroy_users.patch
@@ -1,0 +1,11 @@
+--- CreateAndDestoryUsers.coffee
++++ CreateAndDestoryUsers.coffee
+@@ -21,7 +21,7 @@ module.exports = (grunt) ->
+ 			user.save (error) ->
+ 				throw error if error?
+ 				ONE_WEEK = 7 * 24 * 60 * 60 # seconds
+-				OneTimeTokenHandler.getNewToken user._id, { expiresIn: ONE_WEEK }, (err, token)->
++				OneTimeTokenHandler.getNewToken "password", { expiresIn: ONE_WEEK, email:user.email, user_id: user._id.toString() }, (err, token)->
+ 					return next(err) if err?
+
+ 					console.log ""

--- a/hotfix/2.0.1/disable_project_history.patch
+++ b/hotfix/2.0.1/disable_project_history.patch
@@ -1,0 +1,11 @@
+--- settings.coffee
++++ settings.coffee
+@@ -200,6 +200,8 @@ settings =
+ 		# is not available
+ 		v1:
+ 			url: ""
++		project_history:
++			enabled: false
+ 	references:{}
+ 	notifications:undefined
+


### PR DESCRIPTION
This PR creates a new `hotfix` folder containing patched images only. Hotfix builds should be safer to update compared of building a new image from the scratch, which would require pulling new versions of every service.