### PR TITLE
Remove overriden v1 settings

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -196,10 +196,6 @@ settings =
 			url: "http://localhost:3000"
 			user: httpAuthUser
 			pass: httpAuthPass
-		# overrides v1.url to indicate via Feature Flags that Overleaf V1
-		# is not available
-		v1:
-			url: ""
 		project_history:
 			enabled: false
 	references:{}


### PR DESCRIPTION
Default values are being removed from https://github.com/overleaf/web/blob/master/config/settings.defaults.coffee#L18.

Once this is done setting it to empty string won't be needed.