### PR TITLE
Copy synctex executable to docker host

### DIFF
--- a/runit/clsi-sharelatex/run
+++ b/runit/clsi-sharelatex/run
@@ -20,9 +20,13 @@ fi
 # can be subsequently mounted in TexLive containers on Sandbox Compilation
 SYNCTEX=/var/lib/sharelatex/bin/synctex
 if [ ! -f "$SYNCTEX" ]; then
-    echo ">> Copying syntex executable to the host"
-    mkdir -p /var/lib/sharelatex/bin
-    cp /var/www/sharelatex/clsi/bin/synctex $SYNCTEX
+    if [ "$DISABLE_SYNCTEX_BINARY_COPY" == "true" ]; then
+        echo ">> Copy of synctex executable disabled by DISABLE_SYNCTEX_BINARY_COPY flag, feature may not work"
+    else
+        echo ">> Copying synctex executable to the host"
+        mkdir -p $(dirname $SYNCTEX )
+        cp /var/www/sharelatex/clsi/bin/synctex $SYNCTEX
+    fi
 fi
 
 exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/clsi/app.js >> /var/log/sharelatex/clsi.log 2>&1

--- a/runit/clsi-sharelatex/run
+++ b/runit/clsi-sharelatex/run
@@ -16,4 +16,13 @@ if [ -e '/var/run/docker.sock' ]; then
   usermod -aG dockeronhost www-data
 fi
 
+# Copies over CSLI synctex to the host mounted volume, so it
+# can be subsequently mounted in TexLive containers on Sandbox Compilation
+SYNCTEX=/var/lib/sharelatex/bin/synctex
+if [ ! -f "$SYNCTEX" ]; then
+    echo ">> Copying syntex executable to the host"
+    mkdir -p /var/lib/sharelatex/bin
+    cp /var/www/sharelatex/clsi/bin/synctex $SYNCTEX
+fi
+
 exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/clsi/app.js >> /var/log/sharelatex/clsi.log 2>&1


### PR DESCRIPTION
When using Sandbox Compiles, CLSI starts TexLive containers, and in that process `synctex` executable available in the host mounted in the container.(https://github.com/overleaf/clsi/blob/f285e08ee055e7b0fc0c81d598a61f40cfdebeb4/app/coffee/DockerRunner.coffee#L153)

This PR makes `synctex` available in the host by copying over the executable inside `sharelatex` container into to the mounted volume (https://github.com/overleaf/overleaf/blob/d09b6149e12a343ae9adf9dcbc8afdf6301dc9ee/docker-compose.yml#L21), so it can be subsequently mounted in the TexLive containers.

Contributes to https://github.com/overleaf/issues/issues/2463