### PR TITLE
Hotfix 2.1.1

### DIFF
--- a/hotfix/2.1.1/Dockerfile
+++ b/hotfix/2.1.1/Dockerfile
@@ -1,0 +1,8 @@
+FROM sharelatex/sharelatex:2.1.0
+
+# Patch: defines recaptcha config to fix share-related issues
+# - https://github.com/overleaf/overleaf/issues/684
+ADD add-recaptcha-config.patch /etc/sharelatex/add-recaptcha-config.patch
+RUN cd /etc/sharelatex/ && \
+    patch < add-recaptcha-config.patch
+

--- a/hotfix/2.1.1/add-recaptcha-config.patch
+++ b/hotfix/2.1.1/add-recaptcha-config.patch
@@ -1,0 +1,14 @@
+--- a/settings.coffee
++++ b/settings.coffee
+@@ -180,6 +180,11 @@ settings =
+ 	# cookie with a secure flag (recommended).
+ 	secureCookie: process.env["SHARELATEX_SECURE_COOKIE"]?
+ 
++	recaptcha:
++		disabled:
++			invite: true
++			register: true
++
+ 	# If you are running ShareLaTeX behind a proxy (like Apache, Nginx, etc)
+ 	# then set this to true to allow it to correctly detect the forwarded IP
+ 	# address and http/https protocol information.


### PR DESCRIPTION
The default configuration for reCAPTCHA was removed in web in https://github.com/overleaf/web/commit/5aa830df0339d1b657c92b8585fb0a546224ae71. However not having this configuration causes problems with share-by-email functionality. This PR introduces the default config back to CE settings, fixing the problem.

In order to disable reCAPTCHA completely (https://github.com/overleaf/overleaf/issues/652) this problem needs to be addressed. 

Contributes to https://github.com/overleaf/overleaf/issues/684