### PR TITLE
Set CRYPTO_RANDOM as environment variable at startup time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,6 @@ RUN cd /var/www && node git-revision > revisions.txt
 # Set Environment Variables
 # --------------------------------
 ENV WEB_API_USER "sharelatex"
-# password is regenerated in init_scripts/00_regen_sharelatex_secrets.sh
-ENV WEB_API_PASSWORD "password"
 
 ENV SHARELATEX_APP_NAME "Overleaf Community Edition"
 

--- a/init_scripts/00_regen_sharelatex_secrets.sh
+++ b/init_scripts/00_regen_sharelatex_secrets.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Create random secret keys (twice, once for http auth pass, once for cookie secret).
 CRYPTO_RANDOM=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
-sed -i "0,/CRYPTO_RANDOM/s/CRYPTO_RANDOM/$CRYPTO_RANDOM/" /etc/sharelatex/settings.coffee
+echo "export WEB_API_PASSWORD=$CRYPTO_RANDOM" > /etc/profile.d/crypto.sh
 
 CRYPTO_RANDOM=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
-sed -i "0,/CRYPTO_RANDOM/s/CRYPTO_RANDOM/$CRYPTO_RANDOM/" /etc/sharelatex/settings.coffee
+echo "export CRYPTO_RANDOM=$CRYPTO_RANDOM" >> /etc/profile.d/crypto.sh

--- a/init_scripts/00_regen_sharelatex_secrets.sh
+++ b/init_scripts/00_regen_sharelatex_secrets.sh
@@ -6,7 +6,7 @@
 WEB_API_PASSWORD_FILE=/etc/container_environment/WEB_API_PASSWORD
 CRYPTO_RANDOM_FILE=/etc/container_environment/CRYPTO_RANDOM
 
-if [ ! -f "$WEB_API_PASSWORD_FILE" ]; then
+if [ ! -f "$WEB_API_PASSWORD_FILE" ] || [ ! -f "$CRYPTO_RANDOM_FILE" ]; then
 
     echo "generating random secrets"
 

--- a/init_scripts/00_regen_sharelatex_secrets.sh
+++ b/init_scripts/00_regen_sharelatex_secrets.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
-# Create random secret keys (twice, once for http auth pass, once for cookie secret).
-CRYPTO_RANDOM=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
-echo "export WEB_API_PASSWORD=$CRYPTO_RANDOM" > /etc/profile.d/crypto.sh
 
-CRYPTO_RANDOM=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
-echo "export CRYPTO_RANDOM=$CRYPTO_RANDOM" >> /etc/profile.d/crypto.sh
+# generate secrets and defines them as environment variables
+# https://github.com/phusion/baseimage-docker#centrally-defining-your-own-environment-variables
+
+WEB_API_PASSWORD_FILE=/etc/container_environment/WEB_API_PASSWORD
+CRYPTO_RANDOM_FILE=/etc/container_environment/CRYPTO_RANDOM
+
+if [ ! -f "$WEB_API_PASSWORD_FILE" ]; then
+
+    echo "generating random secrets"
+
+    SECRET=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
+    echo ${SECRET} > ${WEB_API_PASSWORD_FILE}
+
+    SECRET=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev | tr -d '\n+/')
+    echo ${SECRET} > ${CRYPTO_RANDOM_FILE}
+fi
+

--- a/settings.coffee
+++ b/settings.coffee
@@ -3,7 +3,7 @@ Path = require('path')
 # These credentials are used for authenticating api requests
 # between services that may need to go over public channels
 httpAuthUser = "sharelatex"
-httpAuthPass = "CRYPTO_RANDOM" # Randomly generated for you
+httpAuthPass = process.env["WEB_API_PASSWORD"]
 httpAuthUsers = {}
 httpAuthUsers[httpAuthUser] = httpAuthPass
 
@@ -162,7 +162,7 @@ settings =
 	# If provided, a sessionSecret is used to sign cookies so that they cannot be
 	# spoofed. This is recommended.
 	security:
-		sessionSecret: process.env["SHARELATEX_SESSION_SECRET"] or "CRYPTO_RANDOM" # This was randomly generated for you
+		sessionSecret: process.env["SHARELATEX_SESSION_SECRET"] or process.env["CRYPTO_RANDOM"]
 
 	# These credentials are used for authenticating api requests
 	# between services that may need to go over public channels


### PR DESCRIPTION
Solves the problem of having the environment variable not being actually used by the settings file.

By generating a random value for the environment variable at startup time, default settings are populated appropriately using the generated values.

This is a potential approach, there are several suggestions linked in the original ticket.

Fixes https://github.com/overleaf/issues/issues/2643

Cc @jdleesmiller 