### PR TITLE
Removed node6 and updated modules to Node 10

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -28,15 +28,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
 RUN apt-get install -y nodejs
 RUN npm install -g grunt-cli
 
-
-# Install Node6 (required by some services)
-# -----------------------------------------
-RUN wget https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x64.tar.gz && \
-	mkdir -p /opt/nodejs && tar -xzf node-v6.17.1-linux-x64.tar.gz -C /opt/nodejs/ && \
-    cd /opt/nodejs && mv node-v6.17.1-linux-x64 6.17.1 && \
-    ln -s /opt/nodejs/6.17.1/bin/node /usr/bin/node6
-
-
 # Install TexLive
 # ---------------
 RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \

--- a/runit/filestore-sharelatex/run
+++ b/runit/filestore-sharelatex/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 export SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee
-exec /sbin/setuser www-data /usr/bin/node6 /var/www/sharelatex/filestore/app.js >> /var/log/sharelatex/filestore.log 2>&1
+exec /sbin/setuser www-data /usr/bin/node /var/www/sharelatex/filestore/app.js >> /var/log/sharelatex/filestore.log 2>&1

--- a/runit/real-time-sharelatex/run
+++ b/runit/real-time-sharelatex/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 export SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee
-exec /sbin/setuser www-data /usr/bin/node6 /var/www/sharelatex/real-time/app.js >> /var/log/sharelatex/real-time.log 2>&1
+exec /sbin/setuser www-data /usr/bin/node /var/www/sharelatex/real-time/app.js >> /var/log/sharelatex/real-time.log 2>&1


### PR DESCRIPTION
These are the last modules to be migrated to node 10, therefore node6 is not needed anymore. At the moment of PR the version of node is 10.18.1.

