### PR TITLE
Added environment variable for AWS SES region

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -270,6 +270,7 @@ if process.env["SHARELATEX_EMAIL_FROM_ADDRESS"]?
 			#AWS Creds
 			AWSAccessKeyID: process.env["SHARELATEX_EMAIL_AWS_SES_ACCESS_KEY_ID"]
 			AWSSecretKey: process.env["SHARELATEX_EMAIL_AWS_SES_SECRET_KEY"]
+      region: process.env["SHARELATEX_EMAIL_AWS_SES_REGION"] or 'us-east-1'
 
 			#SMTP Creds
 			host: process.env["SHARELATEX_EMAIL_SMTP_HOST"]


### PR DESCRIPTION
By default AWS SES will be used with `us-east-1` region and it requires a manual fix to use another region (see https://github.com/overleaf/web/issues/656)

This MR add the environment variable `SHARELATEX_EMAIL_AWS_SES_REGION` in settings to override the default setting when needed (and still use `us-east-1` by default)